### PR TITLE
Fix closing bracket for useEffect in GameBoard

### DIFF
--- a/src/components/GameBoard/index.jsx
+++ b/src/components/GameBoard/index.jsx
@@ -156,9 +156,11 @@ return () => {
   socket.off('newAttack');
   socket.off('attackComplete');
   socket.off('playerHit');
-  socket.off('savedAttacksUpdate');
-  socket.off('boardConfigUpdate');
+socket.off('savedAttacksUpdate');
+socket.off('boardConfigUpdate');
 };
+
+  }, [socket, isConnected]);
 
   // Handle player movement
   useEffect(() => {


### PR DESCRIPTION
## Summary
- close the initial `useEffect` in `GameBoard` so Next.js can build

## Testing
- `npm run build`
- `npm run lint` *(fails: asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_688b0ad3d7f4832bb15de1a4aab5cb49